### PR TITLE
Add implementation stubs and method to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 __pycache__/
 .pytest_cache
 .vscode
+.idea
+.DS_Store

--- a/python/stubs/Dockerfile
+++ b/python/stubs/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.8-slim
+
+RUN python3 -m pip install pytest

--- a/python/stubs/README.md
+++ b/python/stubs/README.md
@@ -1,0 +1,10 @@
+Start here if you want to try an implement the basic Go specification yourself.
+
+The stubs directory has the stubs for the methods for the implementation in `v1`.
+
+It has tests from `v1` and `v2`.
+
+### Run tests:
+1. Install [`docker-compose`](https://docs.docker.com/compose/install/).
+2. `cd concurrency/python/stubs`
+3. `docker-compose run tests`

--- a/python/stubs/__init__.py
+++ b/python/stubs/__init__.py
@@ -1,0 +1,51 @@
+"""
+The stubs here acompany http://www.doxsey.net/blog/go-concurrency-from-the-ground-up
+"""
+
+
+# Scheduling Methods
+
+
+def go(callback):
+    pass
+
+
+def run():
+    pass
+
+
+# Channel Methods
+
+
+class Channel:
+    pass
+
+def make():
+    return Channel()
+
+
+def len(channel):
+    return 0
+
+
+def cap(channel):
+    return 0
+
+
+def send(channel, value, callback):
+    pass
+
+
+def recv(channel, callback):
+    pass
+
+
+def close(channel):
+    pass
+
+
+# Selection
+
+
+def select(cases, callback=None):
+    pass

--- a/python/stubs/docker-compose.yaml
+++ b/python/stubs/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  tests:
+    build: .
+    volumes:
+      - .:/project
+    entrypoint: python3 -B -m pytest /project --cache-clear -v

--- a/python/stubs/test_buffering.py
+++ b/python/stubs/test_buffering.py
@@ -1,0 +1,11 @@
+from . import select, send, make, close, recv, go, run
+
+
+def test_buffering():
+    def callback(value, ok):
+        assert value == 1
+
+    ch = make(3)
+    go(lambda: send(ch, 1, lambda: send(ch, 2, lambda: send(ch, 3, lambda: close(ch)))))
+    go(lambda: recv(ch, callback))
+    run()

--- a/python/stubs/test_channel.py
+++ b/python/stubs/test_channel.py
@@ -1,0 +1,12 @@
+from . import go, make, run, send
+
+
+def test_send_on_nil_channel():
+    ch = None
+    go(lambda: send(ch, 5, lambda: None))
+    raised = False
+    try:
+        run()
+    except:
+        raised = True
+    assert raised

--- a/python/stubs/test_merge_sort.py
+++ b/python/stubs/test_merge_sort.py
@@ -1,0 +1,85 @@
+from . import go, make, recv, run, send
+
+# Original functions:
+#
+# func ConcurrentMergeSort(xs []int) []int {
+#     switch len(xs) {
+#     case 0:
+#         return nil
+#     case 1, 2:
+#         return merge(xs[:1], xs[1:])
+#     default:
+#         lc, rc := make(chan []int), make(chan []int)
+#         go func() {
+#             lc <- ConcurrentMergeSort(xs[:len(xs)/2])
+#         }()
+#         go func() {
+#             rc <- ConcurrentMergeSort(xs[len(xs)/2:])
+#         }()
+#         return merge(<-lc, <-rc)
+#     }
+# }
+#
+#
+# func merge(l, r []int) []int {
+#     m := make([]int, 0, len(l)+len(r))
+#     for len(l) > 0 || len(r) > 0 {
+#         switch {
+#         case len(l) == 0:
+#             m = append(m, r[0])
+#             r = r[1:]
+#         case len(r) == 0:
+#             m = append(m, l[0])
+#             l = l[1:]
+#         case l[0] <= r[0]:
+#             m = append(m, l[0])
+#             l = l[1:]
+#         case l[0] > r[0]:
+#             m = append(m, r[0])
+#             r = r[1:]
+#         }
+#     }
+#     return m
+# }
+
+
+def merge(l, r):
+    m = []
+    while len(l) > 0 or len(r) > 0:
+        if len(l) == 0:
+            m.append(r[0])
+            r = r[1:]
+        elif len(r) == 0:
+            m.append(l[0])
+            l = l[1:]
+        elif l[0] <= r[0]:
+            m.append(l[0])
+            l = l[1:]
+        else:
+            m.append(r[0])
+            r = r[1:]
+    return m
+
+
+def concurrent_merge_sort(xs, callback):
+    if len(xs) <= 1:
+        callback(xs)
+    else:
+        lc, rc = make(), make()
+        go(lambda: concurrent_merge_sort(xs[:len(xs)//2], lambda l:
+                                         send(lc, l, lambda: None)))
+        go(lambda: concurrent_merge_sort(xs[len(xs)//2:], lambda r:
+                                         send(rc, r, lambda: None)))
+        recv(lc, lambda l, ok:
+             recv(rc, lambda r, ok:
+                  callback(merge(l, r))))
+
+
+def test_concurrent_merge_sort():
+    called = False
+    def callback(result):
+        called = True
+        assert result == [1, 2, 3, 4, 5]
+    concurrent_merge_sort([2, 3, 1, 5, 4], callback)
+    run()
+    assert called

--- a/python/stubs/test_select.py
+++ b/python/stubs/test_select.py
@@ -1,0 +1,63 @@
+from . import Channel, select, send, make, close, recv, go, run
+
+
+def copy(dst: Channel, src: Channel):
+    def onrecv(value, ok):
+        if ok:
+            send(dst, value, lambda: copy(dst, src))
+        else:
+            close(dst)
+    recv(src, onrecv)
+
+
+def fanin(dst: Channel, src1: Channel, src2: Channel):
+    def onrecv1(value, ok):
+        if ok:
+            send(dst, value, lambda: fanin(dst, src1, src2))
+        else:
+            copy(dst, src2)
+
+    def onrecv2(value, ok):
+        if ok:
+            send(dst, value, lambda: fanin(dst, src1, src2))
+        else:
+            copy(dst, src1)
+
+    select([
+        (recv, src1, onrecv1),
+        (recv, src2, onrecv2),
+    ])
+
+
+def sendall(dst: Channel, xs: list):
+    if xs:
+        send(dst, xs[0], lambda: sendall(dst, xs[1:]))
+    else:
+        close(dst)
+
+
+def recvall(src: Channel, callback):
+    values = []
+
+    def onrecv(value, ok):
+        if ok:
+            values.append(value)
+            recv(src, onrecv)
+        else:
+            callback(values)
+    recv(src, onrecv)
+
+
+def test_select():
+    called = False
+    def callback(result):
+        called = True
+        assert [x for x in sorted(result)] == [1, 2, 3, 4, 5, 6]
+
+    c1, c2, c3 = make(), make(), make()
+    go(lambda: sendall(c2, [1, 2, 3]))
+    go(lambda: sendall(c3, [4, 5, 6]))
+    go(lambda: fanin(c1, c2, c3))
+    go(lambda: recvall(c1, callback))
+    run()
+    assert called


### PR DESCRIPTION
For readers who want to try implementing the Go
specifications for themselves, it's nice to start
with the stubs and a set of easy-to-run failing
tests.

This commit takes the implementation from v1,
changes all the implementation details into stubs.
It also takes the tests from v1 and v2, and makes
them easy to run with docker-compose.